### PR TITLE
FaceOverride, fix MakeThumb, reparse skins

### DIFF
--- a/BaseMod.csproj
+++ b/BaseMod.csproj
@@ -163,6 +163,7 @@
     <Compile Include="BaseMod\UIPanelTool.cs" />
     <Compile Include="BaseMod\UtilTools.cs" />
     <Compile Include="BaseMod\Tools.cs" />
+    <Compile Include="ExtendedLoader\FaceOverridePatch.cs" />
     <Compile Include="ExtendedLoader\GenderInjector.cs" />
     <Compile Include="ExtendedLoader\GiftOrderPatch.cs" />
     <Compile Include="ExtendedLoader\CustomProjectionLoadPatch.cs" />

--- a/BaseMod/Harmony_Patch.cs
+++ b/BaseMod/Harmony_Patch.cs
@@ -290,6 +290,52 @@ namespace BaseMod
         }
         private static void LoadBookSkins(Dictionary<string, List<Workshop.WorkshopSkinData>> _bookSkinData)
         {
+            var loader = Singleton<CustomizingResourceLoader>.Instance;
+            var list2 = LoadWorkshopExtendedCustomAppearance();
+            foreach (Workshop.WorkshopAppearanceInfo workshopAppearanceInfo in list2)
+            {
+                try
+                {
+                    if (workshopAppearanceInfo.isClothCustom)
+                    {
+                        Workshop.WorkshopSkinData workshopSkinData;
+                        if (workshopAppearanceInfo is ExtendedWorkshopAppearanceInfo extendedAppearanceInfo)
+                        {
+                            workshopSkinData = new ExtendedWorkshopSkinData
+                            {
+                                dic = extendedAppearanceInfo.clothCustomInfo,
+                                dataName = extendedAppearanceInfo.bookName,
+                                contentFolderIdx = extendedAppearanceInfo.uniqueId,
+                                atkEffectPivotDic = extendedAppearanceInfo.atkEffectPivotDic,
+                                specialMotionPivotDic = extendedAppearanceInfo.specialMotionPivotDic,
+                                motionSoundList = extendedAppearanceInfo.motionSoundList
+                            };
+                        }
+                        else
+                        {
+                            workshopSkinData = new Workshop.WorkshopSkinData
+                            {
+                                dic = workshopAppearanceInfo.clothCustomInfo,
+                                dataName = workshopAppearanceInfo.bookName,
+                                contentFolderIdx = workshopAppearanceInfo.uniqueId
+                            };
+                        }
+                        int num = loader._skinData.Count;
+                        if (loader._skinData.TryGetValue(workshopAppearanceInfo.uniqueId, out Workshop.WorkshopSkinData workshopSkinData1))
+                        {
+                            num = workshopSkinData1.id;
+                            loader._skinData.Remove(workshopAppearanceInfo.uniqueId);
+                        }
+                        workshopSkinData.id = num;
+                        loader._skinData.Add(workshopAppearanceInfo.uniqueId, workshopSkinData);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError("BaseMod XL: error loading workshop skin at " + workshopAppearanceInfo.path);
+                    Debug.LogError(ex);
+                }
+            }
             foreach (ModContent modContent in LoadedModContents)
             {
                 string modDirectory = modContent._dirInfo.FullName;
@@ -309,36 +355,58 @@ namespace BaseMod
                         string[] directories = Directory.GetDirectories(defaultCharDirectory);
                         for (int i = 0; i < directories.Length; i++)
                         {
-                            Workshop.WorkshopAppearanceInfo workshopAppearanceInfo = LoadCustomAppearance(directories[i]);
-                            if (workshopAppearanceInfo != null && workshopAppearanceInfo is ExtendedWorkshopAppearanceInfo extendedAppearanceInfo)
+                            try
                             {
-                                string[] array = directories[i].Split(new char[]
+                                Workshop.WorkshopAppearanceInfo info = LoadCustomAppearance(directories[i]);
+                                if (info != null)
                                 {
-                                    '\\'
-                                });
-                                string bookName = array[array.Length - 1];
-                                extendedAppearanceInfo.path = directories[i];
-                                extendedAppearanceInfo.uniqueId = modId;
-                                extendedAppearanceInfo.bookName = bookName;
-                                if (extendedAppearanceInfo.isClothCustom)
-                                {
-                                    var extendedData = new ExtendedWorkshopSkinData
+                                    string[] array = directories[i].Split(new char[]
+                                        {
+                                        '\\'
+                                        });
+                                    string bookName = array[array.Length - 1];
+                                    info.path = directories[i];
+                                    info.uniqueId = modName;
+                                    info.bookName = bookName;
+                                    if (info.isClothCustom)
                                     {
-                                        dic = extendedAppearanceInfo.clothCustomInfo,
-                                        dataName = extendedAppearanceInfo.bookName,
-                                        contentFolderIdx = extendedAppearanceInfo.uniqueId,
-                                        atkEffectPivotDic = extendedAppearanceInfo.atkEffectPivotDic,
-                                        specialMotionPivotDic = extendedAppearanceInfo.specialMotionPivotDic,
-                                        motionSoundList = extendedAppearanceInfo.motionSoundList,
-                                        id = i
-                                    };
-                                    var oldData = skinlist.Find((Workshop.WorkshopSkinData data) => data.id == i);
-                                    if (oldData != null)
-                                    {
-                                        skinlist.Remove(oldData);
+                                        Workshop.WorkshopSkinData newData;
+                                        if (info is ExtendedWorkshopAppearanceInfo extendedInfo)
+                                        {
+                                            newData = new ExtendedWorkshopSkinData
+                                            {
+                                                dic = extendedInfo.clothCustomInfo,
+                                                dataName = extendedInfo.bookName,
+                                                contentFolderIdx = extendedInfo.uniqueId,
+                                                atkEffectPivotDic = extendedInfo.atkEffectPivotDic,
+                                                specialMotionPivotDic = extendedInfo.specialMotionPivotDic,
+                                                motionSoundList = extendedInfo.motionSoundList,
+                                                id = i
+                                            };
+                                        }
+                                        else
+                                        {
+                                            newData = new Workshop.WorkshopSkinData
+                                            {
+                                                dic = info.clothCustomInfo,
+                                                dataName = info.bookName,
+                                                contentFolderIdx = info.uniqueId,
+                                                id = i
+                                            };
+                                        }
+                                        var oldData = skinlist.Find((Workshop.WorkshopSkinData data) => data.id == i);
+                                        if (oldData != null)
+                                        {
+                                            skinlist.Remove(oldData);
+                                        }
+                                        skinlist.Add(newData);
                                     }
-                                    skinlist.Add(extendedData);
                                 }
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.LogError("BaseMod XL: error reloading skin at " + directories[i]);
+                                Debug.LogError(ex);
                             }
                         }
                     }
@@ -350,44 +418,52 @@ namespace BaseMod
                     string[] directories = Directory.GetDirectories(charDirectory);
                     for (int i = 0; i < directories.Length; i++)
                     {
-                        Workshop.WorkshopAppearanceInfo workshopAppearanceInfo = LoadCustomAppearance(directories[i]);
-                        if (workshopAppearanceInfo != null)
+                        try
                         {
-                            string[] array = directories[i].Split(new char[]
+                            Workshop.WorkshopAppearanceInfo workshopAppearanceInfo = LoadCustomAppearance(directories[i]);
+                            if (workshopAppearanceInfo != null)
                             {
+                                string[] array = directories[i].Split(new char[]
+                                {
                                 '\\'
-                            });
-                            string str = array[array.Length - 1];
-                            workshopAppearanceInfo.path = directories[i];
-                            workshopAppearanceInfo.uniqueId = modId;
-                            workshopAppearanceInfo.bookName = "Custom_" + str;
-                            bool isClothCustom = workshopAppearanceInfo.isClothCustom;
-                            if (isClothCustom)
-                            {
-                                if (workshopAppearanceInfo is ExtendedWorkshopAppearanceInfo extendedAppearanceInfo)
+                                });
+                                string bookName = array[array.Length - 1];
+                                workshopAppearanceInfo.path = directories[i];
+                                workshopAppearanceInfo.uniqueId = modId;
+                                workshopAppearanceInfo.bookName = "Custom_" + bookName;
+                                bool isClothCustom = workshopAppearanceInfo.isClothCustom;
+                                if (isClothCustom)
                                 {
-                                    list.Add(new ExtendedWorkshopSkinData
+                                    if (workshopAppearanceInfo is ExtendedWorkshopAppearanceInfo extendedAppearanceInfo)
                                     {
-                                        dic = extendedAppearanceInfo.clothCustomInfo,
-                                        dataName = extendedAppearanceInfo.bookName,
-                                        contentFolderIdx = extendedAppearanceInfo.uniqueId,
-                                        atkEffectPivotDic = extendedAppearanceInfo.atkEffectPivotDic,
-                                        specialMotionPivotDic = extendedAppearanceInfo.specialMotionPivotDic,
-                                        motionSoundList = extendedAppearanceInfo.motionSoundList,
-                                        id = oldSkins + i
-                                    });
-                                }
-                                else
-                                {
-                                    list.Add(new Workshop.WorkshopSkinData
+                                        list.Add(new ExtendedWorkshopSkinData
+                                        {
+                                            dic = extendedAppearanceInfo.clothCustomInfo,
+                                            dataName = extendedAppearanceInfo.bookName,
+                                            contentFolderIdx = extendedAppearanceInfo.uniqueId,
+                                            atkEffectPivotDic = extendedAppearanceInfo.atkEffectPivotDic,
+                                            specialMotionPivotDic = extendedAppearanceInfo.specialMotionPivotDic,
+                                            motionSoundList = extendedAppearanceInfo.motionSoundList,
+                                            id = oldSkins + i
+                                        });
+                                    }
+                                    else
                                     {
-                                        dic = workshopAppearanceInfo.clothCustomInfo,
-                                        dataName = workshopAppearanceInfo.bookName,
-                                        contentFolderIdx = workshopAppearanceInfo.uniqueId,
-                                        id = oldSkins + i
-                                    });
+                                        list.Add(new Workshop.WorkshopSkinData
+                                        {
+                                            dic = workshopAppearanceInfo.clothCustomInfo,
+                                            dataName = workshopAppearanceInfo.bookName,
+                                            contentFolderIdx = workshopAppearanceInfo.uniqueId,
+                                            id = oldSkins + i
+                                        });
+                                    }
                                 }
                             }
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.LogError("BaseMod XL: error reloading skin at " + directories[i]);
+                            Debug.LogError(ex);
                         }
                     }
                     if (_bookSkinData.ContainsKey(modId))
@@ -398,44 +474,6 @@ namespace BaseMod
                     {
                         _bookSkinData[modId] = list;
                     }
-                }
-            }
-            var loader = Singleton<CustomizingResourceLoader>.Instance;
-            var list2 = LoadWorkshopExtendedCustomAppearance();
-            foreach (Workshop.WorkshopAppearanceInfo workshopAppearanceInfo in list2)
-            {
-                if (workshopAppearanceInfo.isClothCustom)
-                {
-                    Workshop.WorkshopSkinData workshopSkinData;
-                    if (workshopAppearanceInfo is ExtendedWorkshopAppearanceInfo extendedAppearanceInfo)
-                    {
-                        workshopSkinData = new ExtendedWorkshopSkinData
-                        {
-                            dic = extendedAppearanceInfo.clothCustomInfo,
-                            dataName = extendedAppearanceInfo.bookName,
-                            contentFolderIdx = extendedAppearanceInfo.uniqueId,
-                            atkEffectPivotDic = extendedAppearanceInfo.atkEffectPivotDic,
-                            specialMotionPivotDic = extendedAppearanceInfo.specialMotionPivotDic,
-                            motionSoundList = extendedAppearanceInfo.motionSoundList
-                        };
-                    }
-                    else
-                    {
-                        workshopSkinData = new Workshop.WorkshopSkinData
-                        {
-                            dic = workshopAppearanceInfo.clothCustomInfo,
-                            dataName = workshopAppearanceInfo.bookName,
-                            contentFolderIdx = workshopAppearanceInfo.uniqueId
-                        };
-                    }
-                    int num = loader._skinData.Count;
-                    if (loader._skinData.TryGetValue(workshopAppearanceInfo.uniqueId, out Workshop.WorkshopSkinData workshopSkinData1))
-                    {
-                        num = workshopSkinData1.id;
-                        loader._skinData.Remove(workshopAppearanceInfo.uniqueId);
-                    }
-                    workshopSkinData.id = num;
-                    loader._skinData.Add(workshopAppearanceInfo.uniqueId, workshopSkinData);
                 }
             }
         }
@@ -454,46 +492,72 @@ namespace BaseMod
             string workshopDirPath = PlatformManager.Instance.GetWorkshopDirPath();
             if (Directory.Exists(workshopDirPath))
             {
+                originalEyeIndex = 0;
+                originalBrowIndex = 0;
+                originalMouthIndex = 0;
+                originalFrontHairIndex = 0;
+                originalRearHairIndex = 0;
                 foreach (string text in Directory.GetDirectories(workshopDirPath))
                 {
-                    Workshop.WorkshopAppearanceInfo workshopAppearanceInfo = LoadCustomAppearance(text);
-                    if (workshopAppearanceInfo != null && workshopAppearanceInfo is ExtendedWorkshopAppearanceInfo)
+                    try
                     {
-                        list.Add(workshopAppearanceInfo);
-                        string[] array = text.Split(new char[]
+                        Workshop.WorkshopAppearanceInfo info = LoadCustomAppearance(text);
+                        if (info != null)
                         {
+                            list.Add(info);
+                            string[] array = text.Split(new char[]
+                            {
                             '\\'
-                        });
-                        string text2 = array[array.Length - 1];
-                        workshopAppearanceInfo.path = text;
-                        workshopAppearanceInfo.uniqueId = text2;
-                        if (string.IsNullOrWhiteSpace(workshopAppearanceInfo.bookName))
-                        {
-                            workshopAppearanceInfo.bookName = text2;
+                            });
+                            string text2 = array[array.Length - 1];
+                            info.path = text;
+                            info.uniqueId = text2;
+                            if (string.IsNullOrWhiteSpace(info.bookName))
+                            {
+                                info.bookName = text2;
+                            }
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogError("BaseMod XL: error reloading skin at " + text);
+                        Debug.LogError(ex);
                     }
                 }
             }
+            originalEyeIndex = -1;
+            originalBrowIndex = -1;
+            originalMouthIndex = -1;
+            originalFrontHairIndex = -1;
+            originalRearHairIndex = -1;
             string localDirPath = Path.Combine(Application.dataPath, "Mods");
             if (Directory.Exists(localDirPath))
             {
                 foreach (string text in Directory.GetDirectories(localDirPath))
                 {
-                    Workshop.WorkshopAppearanceInfo workshopAppearanceInfo = LoadCustomAppearance(text);
-                    if (workshopAppearanceInfo != null)
+                    try
                     {
-                        list.Add(workshopAppearanceInfo);
-                        string[] array = text.Split(new char[]
+                        Workshop.WorkshopAppearanceInfo workshopAppearanceInfo = LoadCustomAppearance(text);
+                        if (workshopAppearanceInfo != null)
                         {
+                            list.Add(workshopAppearanceInfo);
+                            string[] array = text.Split(new char[]
+                            {
                             '\\'
-                        });
-                        string text2 = array[array.Length - 1];
-                        workshopAppearanceInfo.path = text;
-                        workshopAppearanceInfo.uniqueId = text2;
-                        if (string.IsNullOrWhiteSpace(workshopAppearanceInfo.bookName))
-                        {
-                            workshopAppearanceInfo.bookName = text2;
+                            });
+                            string text2 = array[array.Length - 1];
+                            workshopAppearanceInfo.path = text;
+                            workshopAppearanceInfo.uniqueId = text2;
+                            if (string.IsNullOrWhiteSpace(workshopAppearanceInfo.bookName))
+                            {
+                                workshopAppearanceInfo.bookName = text2;
+                            }
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogError("BaseMod XL: error reloading skin at " + text);
+                        Debug.LogError(ex);
                     }
                 }
             }
@@ -594,7 +658,7 @@ namespace BaseMod
                                 XmlNode resXml = actionNode.Attributes.GetNamedItem("quality");
                                 if (resXml != null)
                                 {
-                                    res = float.Parse(resXml.InnerText, CultureInfo.InvariantCulture);
+                                    res = Tools.ParseFloatSafe(resXml.InnerText);
                                 }
                                 isCustomSize = (size.x != 512 || size.y != 512 || res != 50f);
                             }
@@ -603,16 +667,10 @@ namespace BaseMod
                             XmlNode headNode = actionNode.SelectSingleNode("Head");
                             XmlNode spritePivotXXml = null;
                             XmlNode spritePivotYXml = null;
-                            XmlNode headXXml = null;
-                            XmlNode headYXml = null;
-                            XmlNode headRXml = null;
                             if (isExtended)
                             {
                                 spritePivotXXml = spritePivotNode.Attributes.GetNamedItem("pivot_x_custom");
                                 spritePivotYXml = spritePivotNode.Attributes.GetNamedItem("pivot_y_custom");
-                                headXXml = headNode.Attributes.GetNamedItem("head_x_custom");
-                                headYXml = headNode.Attributes.GetNamedItem("head_y_custom");
-                                headRXml = headNode.Attributes.GetNamedItem("rotation_custom");
                             }
                             if (spritePivotXXml == null)
                             {
@@ -622,26 +680,36 @@ namespace BaseMod
                             {
                                 spritePivotYXml = spritePivotNode.Attributes.GetNamedItem("pivot_y");
                             }
-                            float spritePivotX = float.Parse(spritePivotXXml.InnerText, CultureInfo.InvariantCulture);
-                            float spritePivotY = float.Parse(spritePivotYXml.InnerText, CultureInfo.InvariantCulture);
+                            float spritePivotX = Tools.ParseFloatSafe(spritePivotXXml.InnerText);
+                            float spritePivotY = Tools.ParseFloatSafe(spritePivotYXml.InnerText);
                             Vector2 pivotPos = new Vector2(spritePivotX / (2 * size.x) + 0.5f, spritePivotY / (2 * size.y) + 0.5f);
 
-                            if (headXXml == null)
-                            {
-                                headXXml = headNode.Attributes.GetNamedItem("head_x");
+                            XmlNode headXXml = headNode.Attributes.GetNamedItem("head_x");
+                            XmlNode headYXml = headNode.Attributes.GetNamedItem("head_y");
+                            XmlNode headRXml = headNode.Attributes.GetNamedItem("rotation");
+                            float headX = Tools.ParseFloatSafe(headXXml?.InnerText);
+                            float headY = Tools.ParseFloatSafe(headYXml?.InnerText);
+                            float headRotation = Tools.ParseFloatSafe(headRXml?.InnerText);
+                            FaceOverride faceOverride = FaceOverride.None;
+                            EffectPivot headPivot = null; 
+                            if (isExtended)
+							{
+                                XmlNode faceNode = headNode.Attributes.GetNamedItem("face");
+                                if (Enum.TryParse(faceNode?.InnerText, true, out FaceOverride faceOverride1))
+								{
+                                    faceOverride = faceOverride1;
+								}
+                                headPivot = new EffectPivot()
+                                {
+                                    localPosition = new Vector3(headX, headY, 0),
+                                    localEulerAngles = new Vector3(0, 0, headRotation)
+                                };
+                                SetPivotCoords(headPivot, headNode);
+                                headX = headPivot.localPosition.x;
+                                headY = headPivot.localPosition.y;
+                                headRotation = headPivot.localEulerAngles.z;
                             }
-                            if (headYXml == null)
-                            {
-                                headYXml = headNode.Attributes.GetNamedItem("head_y");
-                            }
-                            float headX = float.Parse(headXXml.InnerText, CultureInfo.InvariantCulture);
-                            float headY = float.Parse(headYXml.InnerText, CultureInfo.InvariantCulture);
                             Vector2 headPos = new Vector2(headX / 100f, headY / 100f);
-                            if (headRXml == null)
-                            {
-                                headRXml = headNode.Attributes.GetNamedItem("rotation");
-                            }
-                            float headRotation = float.Parse(headRXml.InnerText, CultureInfo.InvariantCulture);
                             XmlNode headEnabledXml = headNode.Attributes.GetNamedItem("head_enable");
                             bool headEnabled = true;
                             if (headEnabledXml != null)
@@ -656,21 +724,16 @@ namespace BaseMod
                                 direction = CharacterMotion.MotionDirection.SideView;
                             }
 
-                            List<Vector3> additionalPivotCoords = null;
+                            List<EffectPivot> additionalPivotCoords = null;
                             if (isExtended)
                             {
                                 XmlNodeList additionalPivotNodes = actionNode.SelectNodes("AdditionalPivot");
                                 if (additionalPivotNodes != null)
                                 {
-                                    additionalPivotCoords = new List<Vector3>();
+                                    additionalPivotCoords = new List<EffectPivot>();
                                     foreach (XmlNode additionalPivot in additionalPivotNodes)
                                     {
-                                        XmlNode addPivotX = additionalPivot.Attributes.GetNamedItem("pivot_x");
-                                        XmlNode addPivotY = additionalPivot.Attributes.GetNamedItem("pivot_y");
-                                        XmlNode addPivotR = additionalPivot.Attributes.GetNamedItem("rotation");
-                                        additionalPivotCoords.Add(new Vector3(float.Parse(addPivotX.InnerText, CultureInfo.InvariantCulture) / 100f,
-                                            float.Parse(addPivotY.InnerText, CultureInfo.InvariantCulture) / 100f,
-                                            float.Parse(addPivotR?.InnerText ?? "0", CultureInfo.InvariantCulture)));
+                                        additionalPivotCoords.Add(GetEffectPivot(additionalPivot));
                                     }
                                 }
                             }
@@ -777,7 +840,9 @@ namespace BaseMod
                                     backSpritePath = backSpritePath,
                                     hasBackSkinSprite = hasBackSkinSprite,
                                     backSkinSpritePath = backSkinSpritePath,
-                                    additionalPivots = additionalPivotCoords
+                                    additionalPivots = additionalPivotCoords,
+                                    headPivot = headPivot,
+                                    faceOverride = faceOverride
                                 };
                             }
                             else
@@ -886,84 +951,60 @@ namespace BaseMod
                 atkEffectPivotDic[pivotNode] = GetEffectPivot(effectPivotNode);
             }
         }
-        private static EffectPivot GetEffectPivot(XmlNode effectPivotNode)
+        static EffectPivot GetEffectPivot(XmlNode customPivotNode)
         {
-            EffectPivot atkEffectRoot = new EffectPivot();
-            if (effectPivotNode != null)
+            if (customPivotNode == null)
             {
-                XmlNode positionNode = effectPivotNode.SelectSingleNode("localPosition");
-                if (positionNode != null)
+                return null;
+            }
+            var pivot = new EffectPivot();
+            if ((customPivotNode.Attributes.GetNamedItem("x") ?? customPivotNode.Attributes.GetNamedItem("pivot_x")) is XmlNode xnode)
+            {
+                pivot.localPosition.x = Tools.ParseFloatSafe(xnode.InnerText);
+            }
+            if ((customPivotNode.Attributes.GetNamedItem("y") ?? customPivotNode.Attributes.GetNamedItem("pivot_y")) is XmlNode ynode)
+            {
+                pivot.localPosition.x = Tools.ParseFloatSafe(ynode.InnerText);
+            }
+            if (customPivotNode.Attributes.GetNamedItem("rotation") is XmlNode rnode)
+            {
+                pivot.localEulerAngles.z = Tools.ParseFloatSafe(rnode.InnerText);
+            }
+            SetPivotCoords(pivot, customPivotNode);
+            return pivot;
+        }
+        static void SetPivotCoords(EffectPivot pivot, XmlNode pivotNode)
+		{
+            pivot.localPosition = SetVectorCoords(pivotNode.SelectSingleNode("localPosition"), pivot.localPosition);
+            pivot.localScale = SetVectorCoords(pivotNode.SelectSingleNode("localScale"), pivot.localScale);
+            pivot.localEulerAngles = SetVectorCoords(pivotNode.SelectSingleNode("localEulerAngles"), pivot.localEulerAngles);
+        }
+        static Vector3 SetVectorCoords(XmlNode coordsNode, Vector3 coords)
+        {
+            if (coordsNode != null)
+            {
+                if (coordsNode.Attributes.GetNamedItem("x") is XmlNode xnode)
                 {
-                    XmlNode x = positionNode.Attributes.GetNamedItem("x");
-                    if (x != null)
-                    {
-                        atkEffectRoot.localPosition.x = float.Parse(x.InnerText, CultureInfo.InvariantCulture);
-                    }
-                    XmlNode y = positionNode.Attributes.GetNamedItem("y");
-                    if (y != null)
-                    {
-                        atkEffectRoot.localPosition.y = float.Parse(y.InnerText, CultureInfo.InvariantCulture);
-                    }
-                    XmlNode z = positionNode.Attributes.GetNamedItem("z");
-                    if (z != null)
-                    {
-                        atkEffectRoot.localPosition.z = float.Parse(z.InnerText, CultureInfo.InvariantCulture);
-                    }
+                    coords.x = Tools.ParseFloatSafe(xnode.InnerText);
                 }
-                XmlNode scaleNode = effectPivotNode.SelectSingleNode("localScale");
-                if (scaleNode != null)
+                if (coordsNode.Attributes.GetNamedItem("y") is XmlNode ynode)
                 {
-                    XmlNode x = scaleNode.Attributes.GetNamedItem("x");
-                    if (x != null)
-                    {
-                        atkEffectRoot.localScale.x = float.Parse(x.InnerText, CultureInfo.InvariantCulture);
-                    }
-                    XmlNode y = scaleNode.Attributes.GetNamedItem("y");
-                    if (y != null)
-                    {
-                        atkEffectRoot.localScale.y = float.Parse(y.InnerText, CultureInfo.InvariantCulture);
-                    }
-                    XmlNode z = scaleNode.Attributes.GetNamedItem("z");
-                    if (z != null)
-                    {
-                        atkEffectRoot.localScale.z = float.Parse(z.InnerText, CultureInfo.InvariantCulture);
-                    }
+                    coords.y = Tools.ParseFloatSafe(ynode.InnerText);
                 }
-                XmlNode anglesNode = effectPivotNode.SelectSingleNode("localEulerAngles");
-                if (anglesNode != null)
+                if (coordsNode.Attributes.GetNamedItem("z") is XmlNode znode)
                 {
-                    XmlNode x = anglesNode.Attributes.GetNamedItem("x");
-                    if (x != null)
-                    {
-                        atkEffectRoot.localEulerAngles.x = float.Parse(x.InnerText, CultureInfo.InvariantCulture);
-                    }
-                    XmlNode y = anglesNode.Attributes.GetNamedItem("y");
-                    if (y != null)
-                    {
-                        atkEffectRoot.localEulerAngles.y = float.Parse(y.InnerText, CultureInfo.InvariantCulture);
-                    }
-                    XmlNode z = anglesNode.Attributes.GetNamedItem("z");
-                    if (z != null)
-                    {
-                        atkEffectRoot.localEulerAngles.z = float.Parse(z.InnerText, CultureInfo.InvariantCulture);
-                    }
+                    coords.z = Tools.ParseFloatSafe(znode.InnerText);
                 }
             }
-            return atkEffectRoot;
-        }
-        public class EffectPivot
-        {
-            public Vector3 localPosition = Vector3.zero;
-            public Vector3 localScale = new Vector3(1, 1, 1);
-            public Vector3 localEulerAngles = Vector3.zero;
+            return coords;
         }
         private static void LoadFaceCustom(Dictionary<Workshop.FaceCustomType, Sprite> faceCustomInfo)
         {
-            FaceResourceSet faceResourceSet = new FaceResourceSet();
-            FaceResourceSet faceResourceSet2 = new FaceResourceSet();
-            FaceResourceSet faceResourceSet3 = new FaceResourceSet();
-            HairResourceSet hairResourceSet = new HairResourceSet();
-            HairResourceSet hairResourceSet2 = new HairResourceSet();
+            FaceResourceSet eyeResourceSet = new FaceResourceSet();
+            FaceResourceSet browResourceSet = new FaceResourceSet();
+            FaceResourceSet mouthResourceSet = new FaceResourceSet();
+            HairResourceSet frontHairResourceSet = new HairResourceSet();
+            HairResourceSet rearHairResourceSet = new HairResourceSet();
             foreach (KeyValuePair<Workshop.FaceCustomType, Sprite> keyValuePair in faceCustomInfo)
             {
                 Workshop.FaceCustomType key = keyValuePair.Key;
@@ -971,74 +1012,119 @@ namespace BaseMod
                 switch (key)
                 {
                     case Workshop.FaceCustomType.Front_RearHair:
-                        hairResourceSet2.Default = value;
+                        rearHairResourceSet.Default = value;
                         break;
                     case Workshop.FaceCustomType.Front_FrontHair:
-                        hairResourceSet.Default = value;
+                        frontHairResourceSet.Default = value;
                         break;
                     case Workshop.FaceCustomType.Front_Eye:
-                        faceResourceSet.normal = value;
+                        eyeResourceSet.normal = value;
                         break;
                     case Workshop.FaceCustomType.Front_Brow_Normal:
-                        faceResourceSet2.normal = value;
+                        browResourceSet.normal = value;
                         break;
                     case Workshop.FaceCustomType.Front_Brow_Attack:
-                        faceResourceSet2.atk = value;
+                        browResourceSet.atk = value;
                         break;
                     case Workshop.FaceCustomType.Front_Brow_Hit:
-                        faceResourceSet2.hit = value;
+                        browResourceSet.hit = value;
                         break;
                     case Workshop.FaceCustomType.Front_Mouth_Normal:
-                        faceResourceSet3.normal = value;
+                        mouthResourceSet.normal = value;
                         break;
                     case Workshop.FaceCustomType.Front_Mouth_Attack:
-                        faceResourceSet3.atk = value;
+                        mouthResourceSet.atk = value;
                         break;
                     case Workshop.FaceCustomType.Front_Mouth_Hit:
-                        faceResourceSet3.hit = value;
+                        mouthResourceSet.hit = value;
                         break;
                     case Workshop.FaceCustomType.Side_RearHair_Rear:
-                        hairResourceSet2.Side_Back = value;
+                        rearHairResourceSet.Side_Back = value;
                         break;
                     case Workshop.FaceCustomType.Side_FrontHair:
-                        hairResourceSet.Side_Front = value;
+                        frontHairResourceSet.Side_Front = value;
                         break;
                     case Workshop.FaceCustomType.Side_RearHair_Front:
-                        hairResourceSet2.Side_Front = value;
+                        rearHairResourceSet.Side_Front = value;
                         break;
                     case Workshop.FaceCustomType.Side_Mouth:
-                        faceResourceSet3.atk_side = value;
+                        mouthResourceSet.atk_side = value;
                         break;
                     case Workshop.FaceCustomType.Side_Brow:
-                        faceResourceSet2.atk_side = value;
+                        browResourceSet.atk_side = value;
                         break;
                     case Workshop.FaceCustomType.Side_Eye:
-                        faceResourceSet.atk_side = value;
+                        eyeResourceSet.atk_side = value;
                         break;
                 }
             }
-            faceResourceSet.FillSprite();
-            faceResourceSet2.FillSprite();
-            faceResourceSet3.FillSprite();
+            eyeResourceSet.FillSprite();
+            browResourceSet.FillSprite();
+            mouthResourceSet.FillSprite();
             if (faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_Eye) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Side_Eye))
             {
-                Singleton<CustomizingResourceLoader>.Instance._eyeResources.Add(faceResourceSet);
+                if (originalEyeIndex >= 0 && originalEyeIndex < Singleton<CustomizingResourceLoader>.Instance._eyeResources.Count)
+                {
+                    Singleton<CustomizingResourceLoader>.Instance._eyeResources[originalEyeIndex] = eyeResourceSet;
+                    originalEyeIndex++;
+                }
+                else
+                {
+                    originalEyeIndex = -1;
+                    Singleton<CustomizingResourceLoader>.Instance._eyeResources.Add(eyeResourceSet);
+                }
             }
             if (faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_Brow_Attack) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_Brow_Hit) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_Brow_Normal) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Side_Brow))
             {
-                Singleton<CustomizingResourceLoader>.Instance._browResources.Add(faceResourceSet2);
+                if (originalBrowIndex >= 0 && originalBrowIndex < Singleton<CustomizingResourceLoader>.Instance._browResources.Count)
+                {
+                    Singleton<CustomizingResourceLoader>.Instance._browResources[originalBrowIndex] = browResourceSet;
+                    originalBrowIndex++;
+                }
+                else
+                {
+                    originalBrowIndex = -1;
+                    Singleton<CustomizingResourceLoader>.Instance._browResources.Add(browResourceSet);
+                }
             }
             if (faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_Mouth_Attack) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_Mouth_Hit) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_Mouth_Normal) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Side_Mouth))
             {
-                Singleton<CustomizingResourceLoader>.Instance._mouthResources.Add(faceResourceSet3);
+                if (originalMouthIndex >= 0 && originalMouthIndex < Singleton<CustomizingResourceLoader>.Instance._mouthResources.Count)
+                {
+                    Singleton<CustomizingResourceLoader>.Instance._mouthResources[originalMouthIndex] = mouthResourceSet;
+                    originalMouthIndex++;
+                }
+                else
+                {
+                    originalMouthIndex = -1;
+                    Singleton<CustomizingResourceLoader>.Instance._mouthResources.Add(mouthResourceSet);
+                }
             }
             if (faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_FrontHair) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Side_FrontHair))
             {
-                Singleton<CustomizingResourceLoader>.Instance._frontHairResources.Add(hairResourceSet);
+                if (originalFrontHairIndex >= 0 && originalFrontHairIndex < Singleton<CustomizingResourceLoader>.Instance._frontHairResources.Count)
+                {
+                    Singleton<CustomizingResourceLoader>.Instance._frontHairResources[originalFrontHairIndex] = frontHairResourceSet;
+                    originalFrontHairIndex++;
+                }
+                else
+                {
+                    originalFrontHairIndex = -1;
+                    Singleton<CustomizingResourceLoader>.Instance._frontHairResources.Add(frontHairResourceSet);
+                }
             }
             if (faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Front_RearHair) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Side_RearHair_Front) || faceCustomInfo.ContainsKey(Workshop.FaceCustomType.Side_RearHair_Rear))
             {
-                Singleton<CustomizingResourceLoader>.Instance._rearHairResources.Add(hairResourceSet2);
+                if (originalRearHairIndex >= 0 && originalRearHairIndex < Singleton<CustomizingResourceLoader>.Instance._rearHairResources.Count)
+                {
+                    Singleton<CustomizingResourceLoader>.Instance._rearHairResources[originalRearHairIndex] = rearHairResourceSet;
+                    originalRearHairIndex++;
+                }
+                else
+                {
+                    originalRearHairIndex = -1;
+                    Singleton<CustomizingResourceLoader>.Instance._rearHairResources.Add(rearHairResourceSet);
+                }
             }
         }
         private static void LoadCoreThumbs()
@@ -1687,13 +1773,7 @@ namespace BaseMod
                         __result = bookThumb;
                         return false;
                     }
-                    /*bookThumb = XLRoot.MakeThumbnail(workshopBookSkinData.dic[ActionDetail.Default]);
-                    if (bookThumb != null)
-                    {
-                        BookThumb.Add(__instance.BookId, bookThumb);
-                        __result = bookThumb;
-                        return false;
-                    }*/
+                    //XLRoot.MakeThumbnail(workshopBookSkinData.dic[ActionDetail.Default]);
                 }
             }
             catch (Exception ex)
@@ -1730,14 +1810,8 @@ namespace BaseMod
                     {
                         __result = bookThumb;
                         return false;
-                    }/*
-                    bookThumb = XLRoot.MakeThumbnail(workshopBookSkinData.dic[ActionDetail.Default]);
-                    if (bookThumb != null)
-                    {
-                        BookThumb.Add(__instance.id, bookThumb);
-                        __result = bookThumb;
-                        return false;
-                    }*/
+                    }
+                    //XLRoot.MakeThumbnail(workshopBookSkinData.dic[ActionDetail.Default]);
                 }
             }
             catch (Exception ex)
@@ -4985,7 +5059,7 @@ namespace BaseMod
             }
             foreach (Type type2 in Assembly.LoadFile(Application.dataPath + "/Managed/Assembly-CSharp.dll").GetTypes())
             {
-                if (type2.Name == "PassiveAbilityBase_" + name)
+                if (type2.Name == "GiftPassiveAbility_" + name)
                 {
                     return Activator.CreateInstance(type2) as PassiveAbilityBase;
                 }
@@ -6249,6 +6323,14 @@ namespace BaseMod
             public string path;
             public Sprite sprite;
         }
+
+
+
+        private static int originalEyeIndex = -1;
+        private static int originalBrowIndex = -1;
+        private static int originalMouthIndex = -1;
+        private static int originalFrontHairIndex = -1;
+        private static int originalRearHairIndex = -1;
 
         private static string path = string.Empty;
 

--- a/BaseMod/Tools.cs
+++ b/BaseMod/Tools.cs
@@ -12,6 +12,7 @@ using TMPro;
 using UI;
 using UnityEngine;
 using UnityEngine.Networking;
+using System.Globalization;
 
 namespace BaseMod
 {
@@ -367,6 +368,20 @@ namespace BaseMod
         {
             public T value;
         }
+        public static float ParseFloatSafe(string s)
+        {
+            try
+            {
+                return float.Parse(s.Replace(',', '.').Replace('/', '.'), invariant);
+            }
+            catch (Exception ex)
+            {
+                Debug.Log("BaseMod: could not parse float, using 0 as fallback");
+                Debug.Log(ex);
+                return 0;
+            }
+        }
+        readonly static NumberFormatInfo invariant = CultureInfo.InvariantCulture.NumberFormat;
     }
     public class EffectTypoData_New : EffectTypoData
     {

--- a/ExtendedLoader/ExtendedClothCustomizeData.cs
+++ b/ExtendedLoader/ExtendedClothCustomizeData.cs
@@ -22,7 +22,9 @@ namespace ExtendedLoader
         public string backSpritePath = "";
         public string backSkinSpritePath = "";
         public float resolution = 50f;
-        public List<Vector3> additionalPivots = new List<Vector3>();
+        public List<EffectPivot> additionalPivots = new List<EffectPivot>();
+        public EffectPivot headPivot;
+        public FaceOverride faceOverride;
 
 
         [HarmonyPatch(typeof(ClothCustomizeData), nameof(ClothCustomizeData.LoadSprite))]

--- a/ExtendedLoader/ExtendedType.cs
+++ b/ExtendedLoader/ExtendedType.cs
@@ -9,14 +9,20 @@ namespace ExtendedLoader
     public class ExtendedWorkshopSkinData : WorkshopSkinData
     {
         public List<BookSoundInfo> motionSoundList = new List<BookSoundInfo>();
-        public Dictionary<ActionDetail, Harmony_Patch.EffectPivot> specialMotionPivotDic = new Dictionary<ActionDetail, Harmony_Patch.EffectPivot>();
-        public Dictionary<string, Harmony_Patch.EffectPivot> atkEffectPivotDic = new Dictionary<string, Harmony_Patch.EffectPivot>();
+        public Dictionary<ActionDetail, EffectPivot> specialMotionPivotDic = new Dictionary<ActionDetail, EffectPivot>();
+        public Dictionary<string, EffectPivot> atkEffectPivotDic = new Dictionary<string, EffectPivot>();
     }
     public class ExtendedWorkshopAppearanceInfo : WorkshopAppearanceInfo
     {
         public List<BookSoundInfo> motionSoundList = new List<BookSoundInfo>();
-        public Dictionary<ActionDetail, Harmony_Patch.EffectPivot> specialMotionPivotDic = new Dictionary<ActionDetail, Harmony_Patch.EffectPivot>();
-        public Dictionary<string, Harmony_Patch.EffectPivot> atkEffectPivotDic = new Dictionary<string, Harmony_Patch.EffectPivot>();
+        public Dictionary<ActionDetail, EffectPivot> specialMotionPivotDic = new Dictionary<ActionDetail, EffectPivot>();
+        public Dictionary<string, EffectPivot> atkEffectPivotDic = new Dictionary<string, EffectPivot>();
+    }
+    public class EffectPivot
+    {
+        public Vector3 localPosition = Vector3.zero;
+        public Vector3 localScale = new Vector3(1, 1, 1);
+        public Vector3 localEulerAngles = Vector3.zero;
     }
     public class SkinPartRenderer : WorkshopSkinDataSetter.PartRenderer
     {
@@ -29,4 +35,15 @@ namespace ExtendedLoader
     {
 
     }
+    public class ExtendedCharacterMotion : CharacterMotion
+	{
+        public FaceOverride faceOverride = FaceOverride.None;
+	}
+    public enum FaceOverride
+	{
+        None = -1,
+        Normal = 0,
+        Hit = 6, 
+        Atk = 4
+	}
 }

--- a/ExtendedLoader/FaceOverridePatch.cs
+++ b/ExtendedLoader/FaceOverridePatch.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace ExtendedLoader
+{
+
+	static class FaceOverridePatch
+	{
+		[HarmonyPatch(typeof(CustomizedAppearance), nameof(CustomizedAppearance.RefreshAppearanceByMotion))]
+		[HarmonyTranspiler]
+		static IEnumerable<CodeInstruction> CustomizedAppearanceRefreshTranspiler(IEnumerable<CodeInstruction> instructions)
+		{
+			int count = 0;
+			foreach (var instruction in instructions)
+			{
+				yield return instruction;
+				if (instruction.Is(OpCodes.Ldfld, actionField))
+				{
+					count++;
+					if (count == 2)
+					{
+						yield return new CodeInstruction(OpCodes.Ldarg_1);
+						yield return new CodeInstruction(OpCodes.Call, checkOverride);
+					}
+				}
+			}
+		}
+
+		[HarmonyPatch(typeof(SpecialCustomizedAppearance), nameof(SpecialCustomizedAppearance.RefreshAppearanceByMotion))]
+		[HarmonyTranspiler]
+		static IEnumerable<CodeInstruction> SpecialCustomizedAppearanceRefreshTranspiler(IEnumerable<CodeInstruction> instructions)
+		{
+			bool waiting = true;
+			foreach (var instruction in instructions)
+			{
+				yield return instruction;
+				if (instruction.Is(OpCodes.Ldfld, actionField))
+				{
+					if (waiting)
+					{
+						yield return new CodeInstruction(OpCodes.Ldarg_1);
+						yield return new CodeInstruction(OpCodes.Call, checkOverride);
+					}
+					waiting = false;
+				}
+			}
+		}
+
+		static ActionDetail CheckOverride(ActionDetail originalAction, CharacterMotion motion)
+		{
+			if (motion is ExtendedCharacterMotion extendedMotion && extendedMotion.faceOverride != FaceOverride.None)
+			{
+				return (ActionDetail)extendedMotion.faceOverride;
+			}
+			if (originalAction - ActionDetail.Fire <= 10 && originalAction - ActionDetail.Fire >= 0)
+			{
+				return ActionDetail.Slash;
+			}
+			return originalAction;
+		}
+
+		static readonly FieldInfo actionField = AccessTools.Field(typeof(CharacterMotion), nameof(CharacterMotion.actionDetail));
+		static readonly MethodInfo checkOverride = AccessTools.Method(typeof(FaceOverridePatch), nameof(FaceOverridePatch.CheckOverride));
+	}
+}

--- a/ExtendedLoader/SkinChangeExtensions.cs
+++ b/ExtendedLoader/SkinChangeExtensions.cs
@@ -295,12 +295,7 @@ namespace ExtendedLoader
                             XLRoot.SkinThumb.Add(skinId, sprite);
                             return sprite;
                         }
-                        Sprite newThumb = XLRoot.MakeThumbnail(data.dic[ActionDetail.Default]);
-                        if (newThumb != null)
-                        {
-                            XLRoot.SkinThumb.Add(skinId, newThumb);
-                            return newThumb;
-                        }
+                        //XLRoot.MakeThumbnail(data.dic[ActionDetail.Default]);
                     }
                 }
                 catch (Exception ex)

--- a/ExtendedLoader/ThumbPatch.cs
+++ b/ExtendedLoader/ThumbPatch.cs
@@ -1,13 +1,15 @@
 ﻿using UI;
 using UnityEngine;
 using Workshop;
+using HarmonyLib;
+using System;
 
 namespace ExtendedLoader
 {
     public class ThumbPatch
     {
-        //[HarmonyPatch(typeof(UICustomizeClothsPanel), nameof(UICustomizeClothsPanel.SetPreviewPortrait), new Type[] { typeof(WorkshopSkinData) })]
-        //[HarmonyPrefix]
+        [HarmonyPatch(typeof(UICustomizeClothsPanel), nameof(UICustomizeClothsPanel.SetPreviewPortrait), new Type[] { typeof(WorkshopSkinData) })]
+        [HarmonyPrefix]
         static bool SetPreviewPortraitPrefix(WorkshopSkinData data, UICustomizeClothsPanel __instance)
         {
             Sprite customThumb = data.GetThumbSprite();

--- a/ExtendedLoader/WorkshopSetterPatch.cs
+++ b/ExtendedLoader/WorkshopSetterPatch.cs
@@ -85,38 +85,38 @@ namespace ExtendedLoader
                 }
                 if (extendedData.atkEffectPivotDic != null)
                 {
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectRoot", out Harmony_Patch.EffectPivot atkEffectRoot))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectRoot", out EffectPivot atkEffectRoot))
                     {
                         __instance.Appearance.atkEffectRoot.position = Vector3.zero;
                         __instance.Appearance.atkEffectRoot.localPosition = atkEffectRoot.localPosition;
                         __instance.Appearance.atkEffectRoot.localScale = atkEffectRoot.localScale;
                         __instance.Appearance.atkEffectRoot.localEulerAngles = atkEffectRoot.localEulerAngles;
                     }
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_H", out Harmony_Patch.EffectPivot atkEffectPivot_H))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_H", out EffectPivot atkEffectPivot_H))
                     {
                         __instance.Appearance.atkEffectPivot_H = CreateTransform(__instance.Appearance.atkEffectRoot, "atkEffectPivot_H", atkEffectPivot_H.localPosition, atkEffectPivot_H.localScale, atkEffectPivot_H.localEulerAngles);
                     }
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_J", out Harmony_Patch.EffectPivot atkEffectPivot_J))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_J", out EffectPivot atkEffectPivot_J))
                     {
                         __instance.Appearance.atkEffectPivot_J = CreateTransform(__instance.Appearance.atkEffectRoot, "atkEffectPivot_J", atkEffectPivot_J.localPosition, atkEffectPivot_J.localScale, atkEffectPivot_J.localEulerAngles);
                     }
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_Z", out Harmony_Patch.EffectPivot atkEffectPivot_Z))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_Z", out EffectPivot atkEffectPivot_Z))
                     {
                         __instance.Appearance.atkEffectPivot_Z = CreateTransform(__instance.Appearance.atkEffectRoot, "atkEffectPivot_Z", atkEffectPivot_Z.localPosition, atkEffectPivot_Z.localScale, atkEffectPivot_Z.localEulerAngles);
                     }
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_G", out Harmony_Patch.EffectPivot atkEffectPivot_G))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_G", out EffectPivot atkEffectPivot_G))
                     {
                         __instance.Appearance.atkEffectPivot_G = CreateTransform(__instance.Appearance.atkEffectRoot, "atkEffectPivot_G", atkEffectPivot_G.localPosition, atkEffectPivot_G.localScale, atkEffectPivot_G.localEulerAngles);
                     }
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_E", out Harmony_Patch.EffectPivot atkEffectPivot_E))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_E", out EffectPivot atkEffectPivot_E))
                     {
                         __instance.Appearance.atkEffectPivot_E = CreateTransform(__instance.Appearance.atkEffectRoot, "atkEffectPivot_E", atkEffectPivot_E.localPosition, atkEffectPivot_E.localScale, atkEffectPivot_E.localEulerAngles);
                     }
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_S", out Harmony_Patch.EffectPivot atkEffectPivot_S))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_S", out EffectPivot atkEffectPivot_S))
                     {
                         __instance.Appearance.atkEffectPivot_S = CreateTransform(__instance.Appearance.atkEffectRoot, "atkEffectPivot_S", atkEffectPivot_S.localPosition, atkEffectPivot_S.localScale, atkEffectPivot_S.localEulerAngles);
                     }
-                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_F", out Harmony_Patch.EffectPivot atkEffectPivot_F))
+                    if (extendedData.atkEffectPivotDic.TryGetValue("atkEffectPivot_F", out EffectPivot atkEffectPivot_F))
                     {
                         __instance.Appearance.atkEffectPivot_F = CreateTransform(__instance.Appearance.atkEffectRoot, "atkEffectPivot_F", atkEffectPivot_F.localPosition, atkEffectPivot_F.localScale, atkEffectPivot_F.localEulerAngles);
                     }
@@ -128,7 +128,7 @@ namespace ExtendedLoader
                     {
                         __instance.Appearance._specialMotionPivotList = new List<CharacterAppearance.MotionPivot>();
                     }
-                    foreach (KeyValuePair<ActionDetail, Harmony_Patch.EffectPivot> keyValuePair in extendedData.specialMotionPivotDic)
+                    foreach (KeyValuePair<ActionDetail, EffectPivot> keyValuePair in extendedData.specialMotionPivotDic)
                     {
                         __instance.Appearance._specialMotionPivotList.Add(new CharacterAppearance.MotionPivot()
                         {
@@ -225,15 +225,16 @@ namespace ExtendedLoader
                     }
                     partRenderer.front = spriteRendererFront;
                 }
-                if (transformHead)
-                {
-                    transformHead.localPosition = data.headPos;
-                    transformHead.localRotation = Quaternion.Euler(0f, 0f, data.headRotation);
-                    transformHead.gameObject.SetActive(data.headEnabled);
-                }
                 if (data1 != null)
                 {
                     SkinPartRenderer partRenderer1 = (SkinPartRenderer)partRenderer;
+                    if (transformHead)
+                    {
+                        transformHead.localPosition = data1.headPivot.localPosition;
+                        transformHead.localScale = data1.headPivot.localScale;
+                        transformHead.localRotation = Quaternion.Euler(data1.headPivot.localEulerAngles);
+                        transformHead.gameObject.SetActive(data.headEnabled);
+                    }
                     SpriteRenderer spriteRendererBack = transformBack?.gameObject.GetComponent<SpriteRenderer>();
                     if (spriteRendererBack)
                     {
@@ -274,19 +275,30 @@ namespace ExtendedLoader
                         }
                         partRenderer1.frontSkin = spriteRendererFrontSkin;
                     }
-                    foreach (Vector3 pos in data1.additionalPivots)
+                    for (var i = 0; i < data1.additionalPivots.Count; i++)
                     {
-                        GameObject gameObject = new GameObject("AdditionalPivot");
+                        EffectPivot pivot = data1.additionalPivots[i];
+                        GameObject gameObject = new GameObject("AdditionalPivot_" + i);
                         Transform transform1 = gameObject.transform;
                         transform1.parent = characterMotion.transform;
-                        transform1.localPosition = new Vector2(pos.x, pos.y);
-                        transform1.localScale = new Vector3(1, 1, 1);
-                        transform1.localRotation = Quaternion.Euler(0f, 0f, pos.z);
+                        transform1.localPosition = pivot.localPosition;
+                        transform1.localScale = pivot.localScale;
+                        transform1.localRotation = Quaternion.Euler(pivot.localEulerAngles);
                         characterMotion.additionalPivotList.Add(transform1);
                     }
+                    if (characterMotion is ExtendedCharacterMotion extendedMotion)
+					{
+                        extendedMotion.faceOverride = data1.faceOverride;
+					}
                 }
                 else
                 {
+                    if (transformHead)
+                    {
+                        transformHead.localPosition = data.headPos;
+                        transformHead.localRotation = Quaternion.Euler(0f, 0f, data.headRotation);
+                        transformHead.gameObject.SetActive(data.headEnabled);
+                    }
                     SpriteRenderer spriteRendererBack = transformBack?.gameObject.GetComponent<SpriteRenderer>();
                     if (spriteRendererBack)
                     {


### PR DESCRIPTION
Added a new enum FaceOverride, used as an attribute `face="Normal/Atk/Hit"` in head XML nodes. It forces the character to use the specified face with the motion (please note that side direction always forces Atk anyway). Also fixed assistant librarians using Normal faces for Fire, Aim, Special, and Slash-/Hit-/Penetrate2 motions - they will now use Atk just like patron librarians (unless overridden).
Additional improvements to EffectPivot - it now can be used both in simple (x/y/rotation attributes) and complex (position/scale/euler nodes with x/y/z attributes) notations, with the latter taking precedence if present. Also, complex notation is now applicable to AdditionalPivot's and even Head!
A possible fix for MakeThumbnail taking pictures of the UI - still in testing, so the actual working code is still commented out, but feel free to check it out.
Additional improvement for parsing floats in skin files - now should be able to work with all cases. Additionally, as BaseMod takes priority order, skins are now reloaded regardless of their extended status, to make sure that potential float parsing errors are reparsed before other mods start loading.